### PR TITLE
Finish up the systemcheck page

### DIFF
--- a/core/config/i18n.ini
+++ b/core/config/i18n.ini
@@ -518,7 +518,13 @@ en.syscheck.envCron = "Cronjob"
 en.syscheck.envCron.success = "Cronjob for running database updates is running.<br>Last execution: <strong>%s</strong>"
 en.syscheck.envCron.danger = "ERROR: Cronjob is not active.<br>Consider to install a cronjob for running database updates triggered via sliMpd-GUI"
 
+en.syscheck.envPDO = "PDO module"
+en.syscheck.envPDO.success = "PHP-PDO module successfully detected"
+en.syscheck.envPDO.danger = "Could not detect PHP-PDO, make sure it is installed and enabled"
 
+en.syscheck.envLocale = "Locale"
+en.syscheck.envLocale.success = "The current locale successfully handles UTF-8 characters"
+en.syscheck.envLocale.danger = "UTF-8-compatible locale not enabled, filenames with special characters may encounter errors"
 
 en.cli.arg.invalid = "ERROR: invalid argument %s"
 en.cli.copyright.line1 = "sliMpd (C) Copyright 2016 othmar52 <othmar52@users.noreply.github.com>"

--- a/core/php/Modules/Systemcheck/EnvironmentChecks.php
+++ b/core/php/Modules/Systemcheck/EnvironmentChecks.php
@@ -24,6 +24,8 @@ namespace Slimpd\Modules\Systemcheck;
 trait EnvironmentChecks {
     protected function runEnvironmentChecks(&$check) {
         $this->runCronjobCheck($check);
+        $this->runPDOCheck($check);
+        $this->runLocaleCheck($check);
     }
 
     /**
@@ -33,6 +35,24 @@ trait EnvironmentChecks {
         $check['envCron']['lastHeartBeat'] = \Slimpd\Modules\Importer\CliController::getHeartBeatTstamp();
         if(time() - $check['envCron']['lastHeartBeat'] < 100) {
             $check['envCron']['status'] = 'success';
+        }
+    }
+
+    /**
+     * checks that PDO is installed
+     */
+    protected function runPDOCheck(&$check) {
+        if (extension_loaded('pdo')) {
+            $check['envPDO']['status'] = 'success';
+        }
+    }
+
+    /**
+     * checks that the current locale can handle UTF-8 (by dint of the escapeshellarg function)
+     */
+    protected function runLocaleCheck(&$check) {
+        if (escapeshellarg('/testdir/pathtest-u§s²e³l¼e¬sµsöäüß⁄x/testfile.mp3') === "'/testdir/pathtest-u§s²e³l¼e¬sµsöäüß⁄x/testfile.mp3'") {
+            $check['envLocale']['status'] = 'success';
         }
     }
 }

--- a/core/php/Modules/Systemcheck/Systemcheck.php
+++ b/core/php/Modules/Systemcheck/Systemcheck.php
@@ -75,6 +75,8 @@ class Systemcheck {
 
             // environment
             'envCron'          => array('status' => 'danger', 'hide' => FALSE, 'skip' => FALSE),
+            'envPDO'           => array('status' => 'danger', 'hide' => FALSE, 'skip' => FALSE),
+            'envLocale'        => array('status' => 'danger', 'hide' => FALSE, 'skip' => FALSE),
 
             'skipAudioTests'=> FALSE
         );

--- a/core/templates/partials/systemcheck/env/envLocale-danger.htm
+++ b/core/templates/partials/systemcheck/env/envLocale-danger.htm
@@ -1,0 +1,1 @@
+{{'syscheck.envLocale.danger'|ll|raw}}<br/>

--- a/core/templates/partials/systemcheck/env/envLocale-success.htm
+++ b/core/templates/partials/systemcheck/env/envLocale-success.htm
@@ -1,0 +1,1 @@
+{{'syscheck.envLocale.success'|ll|raw}}<br/>

--- a/core/templates/partials/systemcheck/env/envPDO-danger.htm
+++ b/core/templates/partials/systemcheck/env/envPDO-danger.htm
@@ -1,0 +1,1 @@
+{{'syscheck.envPDO.danger'|ll|raw}}<br/>

--- a/core/templates/partials/systemcheck/env/envPDO-success.htm
+++ b/core/templates/partials/systemcheck/env/envPDO-success.htm
@@ -1,0 +1,1 @@
+{{'syscheck.envPDO.success'|ll|raw}}<br/>

--- a/core/templates/partials/systemcheck/fs/fsConfLocalServe-danger.htm
+++ b/core/templates/partials/systemcheck/fs/fsConfLocalServe-danger.htm
@@ -21,5 +21,12 @@ URL: <a class="dark" href="{{configLocalUrl}}">{{configLocalUrl}}</a><br />
   ...
 </VirtualHost></xmp></pre>
 
-<p>TODO: Add example protection for <strong>nginx</strong><br />
-TODO: Add example protection for <strong>lighttpd</strong></p>
+<h4>Nginx v1.6</h4>
+<pre>server {
+  ...
+  location ~ config_local\.ini$ {
+    return 403;
+  }
+  ...
+}</pre>
+<p>TODO: Add example protection for <strong>lighttpd</strong></p>

--- a/core/templates/partials/systemcheck/layout.htm
+++ b/core/templates/partials/systemcheck/layout.htm
@@ -150,7 +150,7 @@
 
 <h1 id="discogs">{{'syscheck.env'|ll}}</h1>
 <ul class="list-group">
-	{% for test in ['envCron'] %}
+	{% for test in ['envCron', 'envPDO', 'envLocale'] %}
 	{% if not sys[test].hide %}
 	<li class="list-group-item list-group-item-{{sys[test].status}}">
 		<h4 class="uc">
@@ -164,12 +164,6 @@
 	</li>
 	{% endif %}
 	{% endfor %}
-	<li class="list-group-item list-group-item-info">
-		TODO: check if php-pdo is enabled (if (class_exists('PDO')) )
-	</li>
-	<li class="list-group-item list-group-item-info">
-		TODO: check locale settings to avoid errors caused by specialchars
-	</li>
 </ul>
 
 


### PR DESCRIPTION
Issue #4  is actually a matter of locale (see http://php.net/manual/en/function.escapeshellarg.php#99213), and even though it's been worked around, I added a check to make sure `escapeshellarg` handles UTF-8 nicely, just to avoid any other edge cases.