### PR TITLE
Fix page titles

### DIFF
--- a/core/js/backbone-modules/abstract/AbstractPlayer.js
+++ b/core/js/backbone-modules/abstract/AbstractPlayer.js
@@ -202,7 +202,8 @@
                 borderWidth : 1.2,
                 backgroundColor : this.faviconBackgroundColor,
                 titleRenderer : function(v, t){
-                    return $(".player-"+ this.mode +" .now-playing-string").text();
+                    var nowPlaying = $(".player-" + window.sliMpd.currentPlayer.mode + " .now-playing-string").text();
+                    return nowPlaying === "" ? t : t + " - " + nowPlaying;
                 }
             }).setValue(this.nowPlayingPercent);
         },

--- a/core/templates/djscreen.htm
+++ b/core/templates/djscreen.htm
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>{{ config.title }}</title>
+		<title>{{ config.config.title }}</title>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/core/templates/modules/404.htm
+++ b/core/templates/modules/404.htm
@@ -3,7 +3,7 @@
 		<h1 style="font-size:9em; color:#AAA;">LEIDER</h1>
 		<h1 style="font-size:6em;">POPEIDER</h1>
 		<p>Die angeforderte Adresse wurde nicht gefunden.<br />
-		{{ config.title }} steckt ja noch in den Kinderschuhen... <a class="item-link" href="javascript:history.back();">Zurück</a></p>
+		{{ config.config.title }} steckt ja noch in den Kinderschuhen... <a class="item-link" href="javascript:history.back();">Zurück</a></p>
 		
 	</div>
 </div>

--- a/core/templates/surrounding.htm
+++ b/core/templates/surrounding.htm
@@ -1,7 +1,7 @@
 {% if not nosurrounding %}<!DOCTYPE html>
 <html>
 	<head>
-		<title>{{ config.title }}</title>
+		<title>{{ config.config.title }}</title>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
I'm not a huge fan of having to reference `window` directly, but couldn't find a better way without modifying the favicon library.