### PR TITLE
Default to US English for locales

### DIFF
--- a/core/config/config.ini
+++ b/core/config/config.ini
@@ -9,6 +9,9 @@ cli-verbosity = 1
 
 ; currently en, de
 langkey = en
+; When disabled, these use the system defaults
+;locale = de_DE.UTF-8
+;timezone = Europe/Vienna
 
 ; display button for quickly browsing through random items (useful for development)
 showrandomizer = 0
@@ -320,3 +323,6 @@ sticker
 other
 back
 "
+
+[cli]
+memory_limit = 4096M

--- a/core/php/Modules/Localization/Localization.php
+++ b/core/php/Modules/Localization/Localization.php
@@ -45,15 +45,4 @@ class Localization {
         }
         return 'TRNSLT:' . $itemkey;
     }
-
-    public static function setLocaleByLangKey($languageKey) {
-        switch($languageKey) {
-            case 'de':
-                setlocale(LC_ALL, array('de_DE.UTF-8','de_DE@euro','de_DE','german'));
-                break;
-            default:
-                setlocale(LC_ALL, array('en_US.UTF-8','en_US','english'));
-                break;
-        }
-    }
 }

--- a/core/php/Modules/Localization/Localization.php
+++ b/core/php/Modules/Localization/Localization.php
@@ -52,12 +52,7 @@ class Localization {
                 setlocale(LC_ALL, array('de_DE.UTF-8','de_DE@euro','de_DE','german'));
                 break;
             default:
-                // TODO: what is the correct locale-setting for en?
-                // make sure this works correctly:
-                //   var_dump(basename('musicfiles/testdirectory/Ænima-bla')); die();
-                // for now force DE...
-                // setlocale(LC_ALL, array('en_EN.UTF-8','en_EN','en_EN'))
-                setlocale(LC_ALL, array('de_DE.UTF-8','de_DE@euro','de_DE','german'));
+                setlocale(LC_ALL, array('en_US.UTF-8','en_US','english'));
                 break;
         }
     }

--- a/core/php/dependencies.php
+++ b/core/php/dependencies.php
@@ -45,7 +45,6 @@ $container['conf'] = function ($cont) {
 
     $configLoader = new \Slimpd\Modules\configloader_ini\ConfigLoaderINI(APP_ROOT . 'core/config/');
     $config = $configLoader->loadConfig('master.ini', NULL, $noCache);
-    \Slimpd\Modules\Localization\Localization::setLocaleByLangKey($config['config']['langkey']);
 
     if(PHP_SAPI === 'cli') {
         $_SESSION['cliVerbosity'] = $config['config']['cli-verbosity'];

--- a/index.php
+++ b/index.php
@@ -39,8 +39,15 @@ foreach([
     require_once APP_ROOT . 'core' . DS . 'php' . DS . $filePath;
 }
 
-date_default_timezone_set('Europe/Vienna');
-
+// Timezone needs to be set before session_start, the locale is also set here for convience
+$configLoader = new \Slimpd\Modules\configloader_ini\ConfigLoaderINI(APP_ROOT . 'core/config/');
+$config = $configLoader->loadConfig('master.ini');
+if (isset($config['config']['timezone'])) {
+    date_default_timezone_set($config['config']['timezone']);
+}
+if (isset($config['config']['locale'])) {
+    setlocale(LC_ALL, array($config['config']['locale']));
+}
 
 session_start();
 

--- a/slimpd
+++ b/slimpd
@@ -31,10 +31,6 @@ if(PHP_SAPI !== 'cli') {
     exit;
 }
 
-
-ini_set('max_execution_time', 0);
-ini_set('memory_limit', '4096M');    // TODO: move to config
-
 ob_start();
 
 define('DS', DIRECTORY_SEPARATOR);
@@ -55,7 +51,18 @@ foreach([
 // set directory to root
 chdir(dirname(__DIR__)); 
 
-date_default_timezone_set('Europe/Vienna');    // TODO: move to config
+// Timezone needs to be set before session_start, the locale is also set here for convience
+$configLoader = new \Slimpd\Modules\configloader_ini\ConfigLoaderINI(APP_ROOT . 'core/config/');
+$config = $configLoader->loadConfig('master.ini');
+if (isset($config['config']['timezone'])) {
+    date_default_timezone_set($config['config']['timezone']);
+}
+if (isset($config['config']['locale'])) {
+    setlocale(LC_ALL, array($config['config']['locale']));
+}
+
+ini_set('max_execution_time', 0);
+ini_set('memory_limit', $config['cli']['memory_limit']);
 
 session_start();
 


### PR DESCRIPTION
I realize this is Americentric, so if you want it to default to en_GB instead, I can also add a separate config option for the locale instead of inferring it solely from the language key. The German default was the cause of the sporadic issue I mentioned in #46 , although I still have no idea why it only happens sometimes.